### PR TITLE
Increase memory limit to handle boto being a memory hog

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -101,7 +101,7 @@ objects:
             requests:
               memory: "512Mi"
             limits:
-              memory: "1024Mi"
+              memory: "2048Mi"
         restartPolicy: Always
     test: false
     triggers:


### PR DESCRIPTION
So it's not the `maven-index-checker` after all what makes the container eat so much memory.

`Boto` uses a lot of memory when downloading/uploading big file from/to S3.
The archive with pre-built maven index has 560MB and the container then uses almost 2GB.

Other way to solve this would be to revert using S3 and having the index in the image, but I don't like that.