### PR TITLE
Remove old default jobs

### DIFF
--- a/f8a-jobs.py
+++ b/f8a-jobs.py
@@ -61,6 +61,13 @@ def base_url():
 @manager.command
 def initjobs():
     """ initialize default jobs """""
+
+    # TODO: remove this
+    Scheduler.remove_job('bigQueryJob')
+    Scheduler.remove_job('cveCheckJob')
+    Scheduler.remove_job('cveMavenCheckJob')
+    Scheduler.remove_job('githubGatheringJob')
+
     logger.debug("Initializing default jobs")
     Scheduler.register_default_jobs(defaults.DEFAULT_JOB_DIR)
     logger.debug("Default jobs initialized")

--- a/f8a_jobs/scheduler.py
+++ b/f8a_jobs/scheduler.py
@@ -174,6 +174,16 @@ class Scheduler(object):
             except ScheduleJobError as exc:
                 cls.log.error("Failed to register job from file '%s': %s", job_file, str(exc))
 
+    @classmethod
+    def remove_job(cls, job_id):
+        cls.log.error("Removing job '%s'", job_id)
+        scheduler = cls.get_paused_scheduler()
+        try:
+            scheduler.remove_job(job_id)
+        except Exception as e:
+            # non-fatal
+            cls.log.exception(e)
+
 
 def job_execute(handler_name, job_id, **handler_kwargs):
     """ Instantiate and run the handler


### PR DESCRIPTION


```
Traceback (most recent call last):
  File "/usr/lib64/python3.4/site-packages/apscheduler/util.py", line 268, in ref_to_obj
    obj = __import__(modulename, fromlist=[rest])
ImportError: No module named 'bayesian_jobs'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/f8a-jobs.py", line 90, in <module>
    manager.run()
  File "/usr/lib/python3.4/site-packages/flask_script/__init__.py", line 412, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/usr/lib/python3.4/site-packages/flask_script/__init__.py", line 383, in handle
    res = handle(*args, **config)
  File "/usr/lib/python3.4/site-packages/flask_script/commands.py", line 216, in __call__
    return self.run(*args, **kwargs)
  File "/usr/bin/f8a-jobs.py", line 65, in initjobs
    Scheduler.register_default_jobs(defaults.DEFAULT_JOB_DIR)
  File "/usr/lib/python3.4/site-packages/f8a_jobs/scheduler.py", line 172, in register_default_jobs
    job = cls.schedule_job(scheduler, job_info.pop('handler'), **job_info)
  File "/usr/lib/python3.4/site-packages/f8a_jobs/scheduler.py", line 78, in schedule_job
    if scheduler.get_job(job_id) is not None:
  File "/usr/lib64/python3.4/site-packages/apscheduler/schedulers/base.py", line 577, in get_job
    return self._lookup_job(job_id, jobstore)[0]
  File "/usr/lib64/python3.4/site-packages/apscheduler/schedulers/base.py", line 804, in _lookup_job
    job = store.lookup_job(job_id)
  File "/usr/lib64/python3.4/site-packages/apscheduler/jobstores/sqlalchemy.py", line 67, in lookup_job
    return self._reconstitute_job(job_state) if job_state else None
  File "/usr/lib64/python3.4/site-packages/apscheduler/jobstores/sqlalchemy.py", line 122, in _reconstitute_job
    job.__setstate__(job_state)
  File "/usr/lib64/python3.4/site-packages/apscheduler/job.py", line 260, in __setstate__
    self.func = ref_to_obj(self.func_ref)
  File "/usr/lib64/python3.4/site-packages/apscheduler/util.py", line 270, in ref_to_obj
    raise LookupError('Error resolving reference %s: could not import module' % ref)
LookupError: Error resolving reference bayesian_jobs.scheduler:job_execute: could not import module
```