### PR TITLE
maven-index-checker moved to fabric8-analytics repo

### DIFF
--- a/hack/install_maven-index-checker.sh
+++ b/hack/install_maven-index-checker.sh
@@ -6,8 +6,7 @@ if [[ -z "${MAVEN_INDEX_CHECKER_PATH}" ]]; then
     exit 1
 fi
 
-# download
-git clone https://github.com/pkajaba/maven-index-checker.git
+git clone https://github.com/fabric8-analytics/maven-index-checker.git
 cd maven-index-checker
 mvn clean package
 mkdir --mode 775 --parents "${MAVEN_INDEX_CHECKER_PATH}"


### PR DESCRIPTION
It contains a [commit](https://github.com/fabric8-analytics/maven-index-checker/commit/ea1578c5ac369479a5d74c1c4fb9f078e97e3015) with which we get the specified range of packages from the newest end of index (instead of the oldest).