### PR TITLE
Don't sort by popularity by default

### DIFF
--- a/f8a_jobs/swagger.yaml
+++ b/f8a_jobs/swagger.yaml
@@ -310,7 +310,7 @@ parameters:
     required: false
     description: Sorted by popularity
     type: boolean
-    default: true
+    default: false
   ecosystem:
      name: ecosystem
      in: query


### PR DESCRIPTION
Since we have all the "popular" packages already analysed.