### PR TITLE
Move obtaining storage object to ensure it's freshness

### DIFF
--- a/f8a_jobs/handlers/maven_popular_analyses.py
+++ b/f8a_jobs/handlers/maven_popular_analyses.py
@@ -121,7 +121,6 @@ class MavenPopularAnalyses(AnalysesBaseHandler):
         central_index_dir = os.path.join(target_dir, 'central-index')
         timestamp_path = os.path.join(central_index_dir, 'timestamp')
 
-        package_postgres = StoragePool.get_connected_storage('PackagePostgres')
         s3 = StoragePool.get_connected_storage('S3MavenIndex')
         self.log.info('Fetching pre-built maven index from S3, if available.')
         s3.retrieve_index_if_exists(target_dir)
@@ -159,7 +158,8 @@ class MavenPopularAnalyses(AnalysesBaseHandler):
                 name = '{}:{}'.format(release['groupId'], release['artifactId'])
                 version = release['version']
                 # For now (can change in future) we want to analyze only ONE version of each package
-                if package_postgres.get_analysis_count(self.ecosystem, name) > 0:
+                if StoragePool.get_connected_storage('PackagePostgres').\
+                        get_analysis_count(self.ecosystem, name) > 0:
                     self.log.info("Analysis of some version of %s has already been scheduled, "
                                   "skipping version %s", name, version)
                 else:


### PR DESCRIPTION
This is related to https://github.com/fabric8-analytics/fabric8-analytics-worker/issues/47 

I was not able to recreate that issue, but this might ease the problem