### PR TITLE
Bump worker version to pull in semantic_version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Fridolin Pokorny <fridolin@redhat.com>
 
 ENV LANG=en_US.UTF-8 \
     MAVEN_INDEX_CHECKER_PATH='/opt/maven-index-checker' \
-    F8A_WORKER_VERSION=9277c9c
+    F8A_WORKER_VERSION=e8875ac
 
 RUN useradd coreapi
 


### PR DESCRIPTION
https://github.com/fabric8-analytics/fabric8-analytics-worker/commit/e8875ac63e362df42a4973fcd84880ade0a14d02 adds `semantic_version` into requirements.

Fixes:

```
coreapi-jobs            | ImportError: No module named 'semantic_version'
```