### PR TITLE
Get rid of latest_version_only

### DIFF
--- a/f8a_jobs/handlers/base.py
+++ b/f8a_jobs/handlers/base.py
@@ -164,7 +164,6 @@ class AnalysesBaseHandler(BaseHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.nversions = self._DEFAULT_NVERSIONS
-        self.latest_version_only = False
         self.popular = True
         self.count = CountRange(min=1, max=self._DEFAULT_COUNT)
         self.force = False
@@ -253,15 +252,14 @@ class AnalysesBaseHandler(BaseHandler):
         if kwargs.get('recursive_limit') is not None and kwargs['recursive_limit'] < 0:
             raise ValueError("Unable to use negative recursive limit")
 
-    def execute(self, ecosystem, popular=True, count=None, nversions=None, latest_version_only=False,
+    def execute(self, ecosystem, popular=True, count=None, nversions=None,
                 force=False, recursive_limit=None, force_graph_sync=False):
         """Run analyses on maven projects.
 
         :param ecosystem: ecosystem name
         :param popular: boolean, sort index by popularity
         :param count: str, number or range of projects to analyse
-        :param latest_version_only: boolean, whether or not to analyse just latest version
-        :param nversions: how many (most popular) versions of each project to schedule
+        :param nversions: how many latest versions of a project to schedule
         :param force: force analyses scheduling
         :param recursive_limit: number of analyses done transitively
         :param force_graph_sync: force sync to graph DB
@@ -269,7 +267,6 @@ class AnalysesBaseHandler(BaseHandler):
         self.count = self._parse_count(count)
         self.ecosystem = ecosystem
         self.nversions = nversions or self._DEFAULT_NVERSIONS
-        self.latest_version_only = latest_version_only
         self.force = force
         self.recursive_limit = recursive_limit
         self.force_graph_sync = force_graph_sync

--- a/f8a_jobs/handlers/maven_popular_analyses.py
+++ b/f8a_jobs/handlers/maven_popular_analyses.py
@@ -67,16 +67,11 @@ class MavenPopularAnalyses(AnalysesBaseHandler):
                 art = requests.get(artifact_link)
                 artpage = bs4.BeautifulSoup(art.text, 'html.parser')
                 name = artifact[len('/artifact/'):].replace('/', ':')
-                all_versions = self._find_versions(artpage, self.latest_version_only)
+                all_versions = self._find_versions(artpage, self.nversions == 1)
                 if name not in self.projects and all_versions:
-                    if self.latest_version_only:
-                        # all versions is already just the latest version in this case
-                        versions = all_versions
-                        self.log.debug("Scheduling #%d. (latest version)", self.nprojects)
-                    else:
-                        versions = all_versions[:self.nversions]
-                        self.log.debug("Scheduling #%d. (number versions: %d)",
-                                       self.nprojects, self.nversions)
+                    versions = all_versions[:self.nversions]
+                    self.log.debug("Scheduling #%d. (number versions: %d)",
+                                   self.nprojects, self.nversions)
                     self.projects[name] = versions
                     self.nprojects += 1
                     for version in versions:
@@ -146,7 +141,7 @@ class MavenPopularAnalyses(AnalysesBaseHandler):
 
         index_range = '{}-{}'.format(self.count.min, self.count.max)
         command = ['java', '-Xmx768m', '-Djava.io.tmpdir={}'.format(java_temp_dir), '-jar', 'maven-index-checker.jar', '-r', index_range]
-        if self.latest_version_only:
+        if self.nversions == 1:
             command.append('-l')
         with cwd(maven_index_checker_dir):
             try:

--- a/f8a_jobs/handlers/npm_popular_analyses.py
+++ b/f8a_jobs/handlers/npm_popular_analyses.py
@@ -15,7 +15,7 @@ class NpmPopularAnalyses(AnalysesBaseHandler):
         """Schedule analyses of specific versions using skimdb.npmjs.com API"""
         package_info = requests.get(self._URL_REGISTRY + package).json()
 
-        if self.latest_version_only:
+        if self.nversions == 1:
             self.log.debug("Scheduling #%d. (latest version)", self.count.min + offset)
             latest = package_info.get('dist-tags', {}).get('latest', None)
             if latest:
@@ -25,7 +25,7 @@ class NpmPopularAnalyses(AnalysesBaseHandler):
                                package)
         else:
             self.log.debug("Scheduling #%d. (number versions: %d)",
-                            self.count.min + offset, self.nversions)
+                           self.count.min + offset, self.nversions)
             for version in sorted(package_info.get('versions', {}).keys(), reverse=True)[:self.nversions]:
                 self.analyses_selinon_flow(package, version)
 

--- a/f8a_jobs/handlers/nuget_popular_analyses.py
+++ b/f8a_jobs/handlers/nuget_popular_analyses.py
@@ -45,6 +45,8 @@ class NugetPopularAnalyses(AnalysesBaseHandler):
                 url_suffix = package.find(href=compile(r'^/packages/'))['href'].split('/')
                 if len(url_suffix) == 4:
                     name, releases = NugetReleasesFetcher(None).fetch_releases(url_suffix[2])
+                    self.log.debug("Scheduling %d latest versions of %s)",
+                                   self.nversions, name)
                     for release in releases[-self.nversions:]:
                         self.analyses_selinon_flow(name, release)
 
@@ -53,7 +55,5 @@ class NugetPopularAnalyses(AnalysesBaseHandler):
 
         :param popular: boolean, sort index by popularity
         """
-        if self.latest_version_only:
-            self.nversions = 1
         # Use nuget.org for all (popular or not)
         self._scrape_nuget_org()

--- a/f8a_jobs/handlers/python_popular_analyses.py
+++ b/f8a_jobs/handlers/python_popular_analyses.py
@@ -45,16 +45,10 @@ class PythonPopularAnalyses(AnalysesBaseHandler):
         for idx, package in enumerate(packages[self.count.min:self.count.max]):
             releases = client.package_releases(package, True)  # True for show_hidden arg
 
-            if self.latest_version_only:
-                # it seems that versions are always ordered from newest to oldest
-                self.log.debug("Scheduling #%d (latest version)", self.count.min + idx)
-                if releases:
-                    self.analyses_selinon_flow(package, releases[0])
-            else:
-                self.log.debug("Scheduling #%d. (number versions: %d)",
-                               self.count.min + idx, self.nversions)
-                for version in releases[:self.nversions]:
-                    self.analyses_selinon_flow(package, version)
+            self.log.debug("Scheduling #%d. (number versions: %d)",
+                           self.count.min + idx, self.nversions)
+            for version in releases[:self.nversions]:
+                self.analyses_selinon_flow(package, version)
 
     def _use_pypi_ranking(self):
         """Schedule analyses of packages based on PyPI ranking."""
@@ -86,17 +80,12 @@ class PythonPopularAnalyses(AnalysesBaseHandler):
                     self.log.warning('No releases in %s', pop.url)
                     continue
                 versions = self._parse_version_stats(table.find_all('tr'),
-                                                     sort_by_popularity=not self.latest_version_only)
+                                                     sort_by_popularity=self.nversions > 1)
 
-                if self.latest_version_only:
-                    self.log.debug("Scheduling #%d (latest version)",
-                                   self.count.min + packages_count)
-                    self.analyses_selinon_flow(package_name.text, versions[0][0])
-                else:
-                    self.log.debug("Scheduling #%d. (number versions: %d)",
-                                   self.count.min + packages_count, self.nversions)
-                    for version in versions[:self.nversions]:
-                        self.analyses_selinon_flow(package_name.text, version[0])
+                self.log.debug("Scheduling #%d. (number versions: %d)",
+                               self.count.min + packages_count, self.nversions)
+                for version in versions[:self.nversions]:
+                    self.analyses_selinon_flow(package_name.text, version[0])
 
     def do_execute(self, popular=True):
         """Run core analyse on Python packages.

--- a/f8a_jobs/swagger.yaml
+++ b/f8a_jobs/swagger.yaml
@@ -243,7 +243,6 @@ paths:
         - $ref: "#/parameters/popular"
         - $ref: "#/parameters/ecosystem"
         - $ref: "#/parameters/count"
-        - $ref: "#/parameters/latest_version_only"
         - $ref: "#/parameters/nversions"
         - $ref: "#/parameters/force"
         - $ref: "#/parameters/recursive_limit"
@@ -433,18 +432,11 @@ parameters:
     required: false
     description: Skip first <number> most starred projects
     type: integer
-  latest_version_only:
-    name: latest_version_only
-    in: query
-    required: false
-    description: Scan latest version only (if true, `nversions` is ignored)
-    type: boolean
-    default: false
   nversions:
     name: nversions
     in: query
     required: false
-    description: Number of versions of each item
+    description: Number of versions of each item (1 means latest version only)
     type: integer
   force:
     name: force


### PR DESCRIPTION
It's just equivalent of nversions==1

When `latest_version_only` was set to `True`, the `nversions` was ignored and only one latest version of each package was scheduled.

Which is exactly what `nversions==1` does, because `nversions` specifies how many latest versions of each package to schedule.

For a record, the `latest_version_only` was added with: 29062ca, 36cad98, 0e2b45d