### PR TITLE
Un-pause cveCheckJob & pause cveMavenCheckJob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Fridolin Pokorny <fridolin@redhat.com>
 
 ENV LANG=en_US.UTF-8 \
     MAVEN_INDEX_CHECKER_PATH='/opt/maven-index-checker' \
-    F8A_WORKER_VERSION=d562bbb
+    F8A_WORKER_VERSION=78fd5f3
 
 RUN useradd coreapi
 

--- a/f8a_jobs/default_jobs/cveCheckJob.yaml
+++ b/f8a_jobs/default_jobs/cveCheckJob.yaml
@@ -9,4 +9,4 @@
   periodically: 1 day
   # Keep this high so redeployment/downtime does not affect flow scheduling
   misfire_grace_time: 365 days
-  state: paused
+  state: running

--- a/f8a_jobs/default_jobs/cveMavenCheckJob.yaml
+++ b/f8a_jobs/default_jobs/cveMavenCheckJob.yaml
@@ -39,4 +39,4 @@
   periodically: 30 day
   # Keep this high so redeployment/downtime does not affect flow scheduling
   misfire_grace_time: 365 days
-  state: running
+  state: paused


### PR DESCRIPTION
Since https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/292 we haven't used Snyk's outdated vulnerability db anymore and use OSS Index instead.

Let's run the [cveCheckJob](https://github.com/fabric8-analytics/fabric8-analytics-jobs/blob/master/f8a_jobs/default_jobs/cveCheckJob.yaml) again.

It also [has support for Maven now](https://github.com/fabric8-analytics/fabric8-analytics-worker/commit/de4e85c3bf573888374dc1794f87f580918ebe25
) so we can pause [cveMavenCheckJob](https://github.com/fabric8-analytics/fabric8-analytics-jobs/blob/master/f8a_jobs/default_jobs/cveMavenCheckJob.yaml)

Would be nice to also wait for https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/340
