### PR TITLE
Fix golang popular packages job

### DIFF
--- a/f8a_jobs/handlers/base.py
+++ b/f8a_jobs/handlers/base.py
@@ -151,7 +151,7 @@ class AnalysesBaseHandler(BaseHandler):
             return PythonPopularAnalyses.__name__
         elif ecosystem == 'nuget':
             return NugetPopularAnalyses.__name__
-        elif ecosystem == 'golang':
+        elif ecosystem == 'go':
             return GolangPopularAnalyses.__name__
 
         raise ValueError("Unregistered handler for ecosystem '{}'".format(ecosystem))

--- a/f8a_jobs/handlers/golang_popular_analyses.py
+++ b/f8a_jobs/handlers/golang_popular_analyses.py
@@ -15,37 +15,46 @@ class GolangPopularAnalyses(AnalysesBaseHandler):
         response = requests.get(endpoint)
         response.raise_for_status()
 
-        packages_seen = 0
-        scheduled = 0
+        packages_seen = set()
+        packages_seen_count = 0
+        packages_scheduled = 0
+        finished = False
         for top_category in response.json():
+            if finished:
+                break
             if top_category['Name'] == 'Sites':
                 # This category does not list popular packages...
                 continue
             self.log.info("Inspecting popular packages from category '%s'", top_category['Name'])
             for package in top_category['Items']:
-                packages_seen += 1
+                packages_seen_count += 1
+                if package['Package'] in packages_seen:
+                    self.log.debug("%s already seen" % package['Package'])
+                    continue
+                packages_seen.add(package['Package'])
 
-                if packages_seen > self.count.max:
+                if packages_seen_count > self.count.max:
                     self.log.info("Scheduling of popular golang packages reached requested maximum")
+                    finished = True  # to break the outer loop
                     break
 
-                if packages_seen < self.count.min:
+                if packages_seen_count < self.count.min:
                     self.log.info("Skipping %d. entry '%s' - not in supplied range %s",
-                                  packages_seen, package['Package'], self.count)
+                                  packages_seen_count, package['Package'], self.count)
 
                 # Use directly import path as a package name
                 self.run_selinon_flow('bayesianPackageFlow', {
-                    'ecosystem': 'golang',
+                    'ecosystem': self.ecosystem,
                     'name': package['Package'],
                     'url': package['Package'] or None,
                     'force': self.force
                 })
-                scheduled += 1
+                packages_scheduled += 1
             else:
                 break
 
         self.log.info("Job has finished - scheduled analyses for %d most popular golang projects",
-                      scheduled)
+                      packages_scheduled)
 
     def _packages(self):
         """Schedule analyses of packages in golang (no sort criteria)."""
@@ -54,18 +63,19 @@ class GolangPopularAnalyses(AnalysesBaseHandler):
         response = requests.get(endpoint)
         response.raise_for_status()
 
-        scheduled = 0
+        packages_scheduled = 0
         for idx, import_path in enumerate(response.json()[self.count.min:self.count.max]):
             self.log.info("Package %d. in golang ecosystem '%s'", idx, import_path)
             self.run_selinon_flow('bayesianPackageFlow', {
-                'ecosystem': 'golang',
+                'ecosystem': self.ecosystem,
                 'name': import_path,
                 'url': import_path,
                 'force': self.force
             })
-            scheduled += 1
+            packages_scheduled += 1
 
-        self.log.info("Job has finished - scheduled analyses for %d golang projects", scheduled)
+        self.log.info("Job has finished - scheduled analyses for %d golang projects",
+                      packages_scheduled)
 
     def do_execute(self, popular=True):
         """Run core analyse on golang packages.

--- a/f8a_jobs/handlers/golang_popular_analyses.py
+++ b/f8a_jobs/handlers/golang_popular_analyses.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 import requests
 from .base import AnalysesBaseHandler
 
@@ -7,6 +8,22 @@ class GolangPopularAnalyses(AnalysesBaseHandler):
 
     # API documentation: http://go-search.org/infoapi
     _URL = 'http://go-search.org/api'
+
+    def _get_latest_commit(self, package):
+        if package.startswith('github.com'):
+            url = 'https://{p}/commits/master'.format(p=package)
+            response = requests.get(url)
+            if response.status_code == 200:
+                page = BeautifulSoup(response.text, 'html.parser')
+                commit_links = page.find_all(class_='commit-links-group BtnGroup')
+                if commit_links:
+                    commit_tag = commit_links[0].find_next('a')
+                    if commit_tag:
+                        link = commit_tag.get('href', '')
+                        if link and '/' in link:
+                            return link.split('/')[-1]
+        self.log.warning("Couldn't get latest commit for %s", package)
+        return None
 
     def _popular_packages(self):
         """Schedule analyses of popular packages in golang."""
@@ -41,15 +58,12 @@ class GolangPopularAnalyses(AnalysesBaseHandler):
                 if packages_seen_count < self.count.min:
                     self.log.info("Skipping %d. entry '%s' - not in supplied range %s",
                                   packages_seen_count, package['Package'], self.count)
+                    continue
 
-                # Use directly import path as a package name
-                self.run_selinon_flow('bayesianPackageFlow', {
-                    'ecosystem': self.ecosystem,
-                    'name': package['Package'],
-                    'url': package['Package'] or None,
-                    'force': self.force
-                })
-                packages_scheduled += 1
+                version = self._get_latest_commit(package['Package'])
+                if version:
+                    self.analyses_selinon_flow(name=package['Package'], version=version)
+                    packages_scheduled += 1
             else:
                 break
 
@@ -59,20 +73,16 @@ class GolangPopularAnalyses(AnalysesBaseHandler):
     def _packages(self):
         """Schedule analyses of packages in golang (no sort criteria)."""
         endpoint = self._URL + '?action=packages'
-
         response = requests.get(endpoint)
         response.raise_for_status()
 
         packages_scheduled = 0
-        for idx, import_path in enumerate(response.json()[self.count.min:self.count.max]):
+        for idx, import_path in enumerate(response.json()[self.count.min - 1:self.count.max]):
             self.log.info("Package %d. in golang ecosystem '%s'", idx, import_path)
-            self.run_selinon_flow('bayesianPackageFlow', {
-                'ecosystem': self.ecosystem,
-                'name': import_path,
-                'url': import_path,
-                'force': self.force
-            })
-            packages_scheduled += 1
+            version = self._get_latest_commit(import_path)
+            if version:
+                self.analyses_selinon_flow(name=import_path, version=version)
+                packages_scheduled += 1
 
         self.log.info("Job has finished - scheduled analyses for %d golang projects",
                       packages_scheduled)

--- a/f8a_jobs/swagger.yaml
+++ b/f8a_jobs/swagger.yaml
@@ -489,7 +489,7 @@ parameters:
        - npm
        - pypi
        - nuget
-       - golang
+       - go
   count:
     name: count
     in: query


### PR DESCRIPTION
I don't know how many golang packages is out there, but http://go-search.org/api?action=packages contains over 750000, so I guess it's most of them. And they seem to be sorted by popularity too.

For now the getting of latest commit works only for packages on github.com, but it's still over 730000.

Requires https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/376