### PR TITLE
Set default value to job_type parameter of 'GET /jobs'

### DIFF
--- a/f8a_jobs/swagger.yaml
+++ b/f8a_jobs/swagger.yaml
@@ -782,6 +782,7 @@ parameters:
        - all
        - failed
        - user
+     default: all
   popular:
     name: popular
     in: query


### PR DESCRIPTION
So I don't have to select it each time