### PR TITLE
Change default value of 'state' from 'paused' to 'running'

### DIFF
--- a/f8a_jobs/swagger.yaml
+++ b/f8a_jobs/swagger.yaml
@@ -794,8 +794,8 @@ parameters:
     items:
       type: string
     enum:
-      - paused
       - running
+      - paused
   job_type:
      name: job_type
      in: query


### PR DESCRIPTION
Do I really need to **always** check/switch this value before submitting a job ?