### PR TITLE
chore: Golang flow name handling

### DIFF
--- a/f8a_jobs/graph_ingestion.py
+++ b/f8a_jobs/graph_ingestion.py
@@ -10,9 +10,6 @@ logger = logging.getLogger(__name__)
 _INVOKE_API_WORKERS = True \
     if os.environ.get('INVOKE_API_WORKERS', '1') == '1' \
     else False
-_FLOW_NAME = 'bayesianApiFlow' \
-    if os.environ.get('WORKER_ADMINISTRATION_REGION', 'api') == 'api' \
-    else 'bayesianFlow'
 _SUPPORTED_ECOSYSTEMS = {'npm', 'maven', 'pypi', 'golang'}
 
 
@@ -67,7 +64,10 @@ def ingest_epv_into_graph(epv_details):
                             "version": item.get('version')
                         }
 
-                        flow_name = _FLOW_NAME
+                        flow_name = 'newPackageFlow' \
+                            if ecosystem == 'golang' \
+                            else 'bayesianApiFlow'
+
                         if 'flow_name' in input_data:
                             flow_name = input_data['flow_name']
 

--- a/requirements.in
+++ b/requirements.in
@@ -19,5 +19,4 @@ requests-oauthlib<=1.1.0
 uwsgi
 psycopg2-binary
 jsonschema<=2.6.0
-f8a_utils @ git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@44c123b#egg=f8a_utils
-f8a_worker @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@32bf84c#egg=f8a_worker
+f8a_worker @ git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@6a7e367#egg=f8a_worker

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,41 +4,42 @@
 #
 #    pip-compile
 #
-amqp==2.6.1               # via kombu
+amqp==5.0.2               # via kombu
 anymarkup-core==0.8.1     # via anymarkup
 anymarkup==0.8.1          # via f8a-worker
 apscheduler==3.6.3        # via -r requirements.in
-beautifulsoup4==4.9.1     # via -r requirements.in, f8a-worker
+beautifulsoup4==4.9.3     # via -r requirements.in, bs4, f8a-worker
 billiard==3.6.3.0         # via celery
 blinker==1.4              # via raven
-boto3==1.14.51            # via -r requirements.in, f8a-worker
-botocore==1.17.51         # via -r requirements.in, boto3, f8a-worker, s3transfer
-celery==4.4.7             # via selinon
-certifi==2020.6.20        # via requests
+boto3==1.16.25            # via -r requirements.in, f8a-worker
+botocore==1.19.25         # via -r requirements.in, boto3, f8a-worker, s3transfer
+bs4==0.0.1                # via f8a-utils
+celery==5.0.2             # via selinon
+certifi==2020.11.8        # via requests
+cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.2              # via anymarkup, clickclick, flask, json2sql, selinon
-clickclick==1.2.2         # via connexion
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via anymarkup, celery, click-didyoumean, click-repl, clickclick, flask, json2sql, selinon
+clickclick==20.10.2       # via connexion
 codegen==1.0              # via selinon
-colorama==0.4.3           # via radon, rainbow-logging-handler
+colorama==0.4.4           # via rainbow-logging-handler
 configobj==5.0.6          # via anymarkup
 connexion[swagger-ui]==2.7.0  # via -r requirements.in
-daiquiri==2.1.1           # via json2sql
-docutils==0.15.2          # via botocore
-git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@44c123b#egg=f8a_utils  # via -r requirements.in
+cryptography==3.2.1       # via f8a-utils
+daiquiri==3.0.0           # via json2sql
+git+https://github.com/fabric8-analytics/fabric8-analytics-utils.git@5a5ce60#egg=f8a_utils  # via f8a-worker
 git+https://github.com/fabric8-analytics/fabric8-analytics-version-comparator.git@8a57ac7#egg=f8a_version_comparator  # via f8a-utils
-git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@32bf84c#egg=f8a_worker
-flake8-polyfill==1.0.2    # via radon
-flake8==3.8.3             # via flake8-polyfill
+git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@6a7e367#egg=f8a_worker  # via -r requirements.in
 flask-oauthlib==0.9.4     # via -r requirements.in
 flask-script==2.0.6       # via -r requirements.in
 flask==1.1.2              # via -r requirements.in, connexion, flask-oauthlib, flask-script, raven
-flexmock==0.10.4          # via f8a-worker
 git2json==0.2.3           # via f8a-worker
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.7          # via f8a-worker
-graphviz==0.14.1          # via selinon
+gitpython==3.1.11         # via f8a-worker
+graphviz==0.15            # via selinon
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via flake8, kombu
+importlib-metadata==3.1.0  # via kombu
 inflection==0.5.1         # via connexion
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask, swagger-ui-bundle
@@ -47,46 +48,45 @@ jsl==0.2.4                # via f8a-worker
 json2sql==1.0.0rc1        # via -r requirements.in
 json5==0.9.5              # via anymarkup
 jsonschema==2.6.0         # via -r requirements.in, connexion, f8a-worker, openapi-spec-validator, selinon
-kombu==4.6.11             # via celery
+kombu==5.0.2              # via celery
 logutils==0.3.5           # via rainbow-logging-handler
-lxml==4.5.2               # via f8a-utils, f8a-worker
-mando==0.6.4              # via radon
+lxml==4.6.2               # via f8a-utils, f8a-worker
 markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via flake8
 mosql==0.12.3             # via json2sql
 oauthlib==2.1.0           # via flask-oauthlib, requests-oauthlib
 openapi-spec-validator==0.2.9  # via connexion
-psycopg2-binary==2.8.5    # via -r requirements.in
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
+prompt-toolkit==3.0.8     # via click-repl
+psycopg2-binary==2.8.6    # via -r requirements.in
+pycparser==2.20           # via cffi
 python-dateutil==2.8.1    # via -r requirements.in, botocore
-python-json-logger==0.1.11  # via daiquiri
+python-json-logger==2.0.1  # via daiquiri
 pytimeparse==1.1.8        # via -r requirements.in
-pytz==2020.1              # via apscheduler, celery, tzlocal
+pytz==2020.4              # via apscheduler, celery, tzlocal
 pyyaml==5.3.1             # via -r requirements.in, anymarkup, clickclick, connexion, f8a-worker, json2sql, openapi-spec-validator, selinon
-radon==3.0.1              # via f8a-worker
 rainbow-logging-handler==2.2.2  # via selinon
 raven[flask]==6.10.0      # via -r requirements.in, f8a-worker
 requests-futures==1.0.0   # via f8a-worker
 requests-oauthlib==1.1.0  # via -r requirements.in, flask-oauthlib
-requests==2.24.0          # via -r requirements.in, connexion, f8a-utils, f8a-worker, requests-futures, requests-oauthlib
+requests==2.25.0          # via -r requirements.in, connexion, f8a-utils, f8a-worker, requests-futures, requests-oauthlib
 s3transfer==0.3.3         # via boto3
 selinon[celery]==1.0.0    # via -r requirements.in, f8a-worker
 semantic-version==2.8.5   # via f8a-worker
-six==1.15.0               # via anymarkup-core, apscheduler, configobj, mando, openapi-spec-validator, python-dateutil, tenacity
+semver==2.13.0            # via f8a-utils
+six==1.15.0               # via anymarkup-core, apscheduler, click-repl, configobj, cryptography, openapi-spec-validator, python-dateutil, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
-sqlalchemy==1.3.19        # via -r requirements.in, f8a-worker
+sqlalchemy==1.3.20        # via -r requirements.in, f8a-worker
 swagger-ui-bundle==0.0.8  # via connexion
-tenacity==6.2.0           # via f8a-worker
+tenacity==6.2.0           # via f8a-utils, f8a-worker
 toml==0.9.4               # via anymarkup, f8a-worker
 tzlocal==2.1              # via apscheduler
-urllib3==1.25.10          # via botocore, requests
+urllib3==1.26.2           # via botocore, requests
 uwsgi==2.0.19.1           # via -r requirements.in
-vine==1.3.0               # via amqp, celery
+vine==5.0.0               # via amqp, celery
+wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==0.16.1          # via -r requirements.in, f8a-worker, flask
 xmltodict==0.12.0         # via anymarkup
-zipp==3.1.0               # via importlib-metadata
+zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 codecov
+radon

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,23 +4,26 @@
 #
 #    pip-compile
 #
-attrs==20.1.0             # via pytest
-certifi==2020.6.20        # via requests
+attrs==20.3.0             # via pytest
+certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements.in
-coverage==5.2.1           # via codecov, pytest-cov
+codecov==2.1.10           # via -r requirements.in
+colorama==0.4.4           # via radon
+coverage==5.3             # via codecov, pytest-cov
+future==0.18.2            # via radon
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via pluggy, pytest
-iniconfig==1.0.1          # via pytest
-more-itertools==8.4.0     # via pytest
-packaging==20.4           # via pytest
+importlib-metadata==3.1.0  # via pluggy, pytest
+iniconfig==1.1.1          # via pytest
+mando==0.6.4              # via radon
+packaging==20.7           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements.in
-pytest==6.0.1             # via -r requirements.in, pytest-cov
-requests==2.24.0          # via codecov
-six==1.15.0               # via packaging
-toml==0.10.1              # via pytest
-urllib3==1.25.10          # via requests
-zipp==3.1.0               # via importlib-metadata
+pytest==6.1.2             # via -r requirements.in, pytest-cov
+radon==4.3.2              # via -r requirements.in
+requests==2.25.0          # via codecov
+six==1.15.0               # via mando
+toml==0.10.2              # via pytest
+urllib3==1.26.2           # via requests
+zipp==3.4.0               # via importlib-metadata


### PR DESCRIPTION
Currently flow name is decided based on environment variable "WORKER_ADMINISTRATION_REGION" so it can have only 2 default flow names i.e. bayesianFlow/bayesianApiFlow.
In that case for Golang flow name has to be sent with request body which makes is difficult to manage if we update flow name. To avoid that API calls are set as default i.e.bayesianApiFlow/newPackageFlow, because these flows will be triggered by front end components like API server/Backbone and other Ingestion flows like bayesianFlow, bayesianAnalysisFlow, newPackageAnalysisFlow will be called by back end components only like Github refresh where we can send flow name with body and update if needed.

Also updated the worker version to latest.