### PR TITLE
fix: auth free ingestion end point for internal use

### DIFF
--- a/f8a_jobs/api_spec.yaml
+++ b/f8a_jobs/api_spec.yaml
@@ -148,7 +148,7 @@ paths:
 
         500:
           description: Internal Server Error
-          content:info
+          content:
             application/json:
               schema:
                 type: object
@@ -257,7 +257,6 @@ components:
         - ecosystem
         - packages
         - task_names
-        - flow_name
       properties:
         ecosystem:
           type: string

--- a/f8a_jobs/api_spec.yaml
+++ b/f8a_jobs/api_spec.yaml
@@ -89,6 +89,74 @@ paths:
                     type: string
                     example: Failed to initiate worker flow.
 
+  /internal/ingestions/epv:
+    post:
+      tags:
+        - Ingestion Process
+      description: Internal API to trigger a Selinon flow for ingestion of provided EPV.
+      operationId: f8a_jobs.graph_ingestion.ingest_epv_internal
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestPackageDetailsEPV"
+
+      responses:
+        201:
+          description: Response with Selinon dispacher ID.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ResponsePackageErrorDetails"
+                  - $ref: "#/components/schemas/ResponsePackageDetails"
+
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Failed to initiate worker flow.
+
+  /internal/ingestions/epv-selective:
+    post:
+      tags:
+        - Ingestion Process
+      description: Internal API to trigger a Selinon partial flow for ingestion of provided EPV.
+      operationId: f8a_jobs.graph_ingestion.ingest_selective_epv_internal
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestPackageDetailsSelctiveEPV"
+
+      responses:
+        201:
+          description: Response with Selinon dispacher ID.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ResponsePackageErrorDetails"
+                  - $ref: "#/components/schemas/ResponsePackageDetails"
+
+        500:
+          description: Internal Server Error
+          content:info
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Failed to initiate worker flow.
+
 components:
   schemas:
     ResponsePackageDetails:
@@ -177,6 +245,9 @@ components:
         flow_name:
           type: string
           example: <flow_name>
+        source:
+          type: string
+          example: <name_of_consumer>
 
     RequestPackageDetailsSelctiveEPV:
       title: Selective API Request Body

--- a/f8a_jobs/api_spec.yaml
+++ b/f8a_jobs/api_spec.yaml
@@ -159,19 +159,59 @@ paths:
 
 components:
   schemas:
+    Ecosystem:
+      title: Ecosystem
+      description: List of supported package ecosystems
+      type: string
+      enum:
+        - maven
+        - pypi
+        - npm
+        - golang
+      example: maven
+
+    Flows:
+      title: Flow Name
+      description: List of Selinon worker flow names
+      type: string
+      enum:
+        - osioAnalysisFlow
+        - bayesianFlow
+        - bayesianApiFlow
+        - bayesianPriorityFlow
+        - bayesianAnalysisFlow
+        - livenessFlow
+        - bayesianPackageFlow
+        - bayesianApiPackageFlow
+        - bayesianPriorityPackageFlow
+        - bayesianPackageAnalysisFlow
+        - componentApiFlow
+        - dependencyIngestFlow
+        - osioUserNotificationFlow
+        - gitOperationsFlow
+        - golangCVEPredictionsFlow
+        - newPackageFlow
+        - newPackageAnalysisFlow
+      example: bayesianFlow
+
+    Source:
+      title: Source
+      description: List of alias of consumers
+      type: string
+      enum:
+        - api
+        - git-refresh
+        - report
+        - monitor
+      example: api
+
     ResponsePackageDetails:
       title: API Response Body
       description: If request is procesed successfully, Selinon dispacher ID will be sent back.
       type: object
       properties:
         ecosystem:
-          type: string
-          enum:
-            - maven
-            - pypi
-            - npm
-            - golang
-          example: maven
+          $ref: '#/components/schemas/Ecosystem'
         packages:
           type: array
           items:
@@ -193,13 +233,7 @@ components:
       type: object
       properties:
         ecosystem:
-          type: string
-          enum:
-            - maven
-            - pypi
-            - npm
-            - golang
-          example: maven
+          $ref: '#/components/schemas/Ecosystem'
         packages:
           type: array
           items:
@@ -224,13 +258,7 @@ components:
         - packages
       properties:
         ecosystem:
-          type: string
-          enum:
-            - maven
-            - pypi
-            - npm
-            - golang
-          example: maven
+          $ref: '#/components/schemas/Ecosystem'
         packages:
           type: array
           items:
@@ -255,34 +283,9 @@ components:
           type: integer
           example: 0
         flow_name:
-          type: string
-          example: bayesianFlow
-          enum:
-            - osioAnalysisFlow
-            - bayesianFlow
-            - bayesianApiFlow
-            - bayesianPriorityFlow
-            - bayesianAnalysisFlow
-            - livenessFlow
-            - bayesianPackageFlow
-            - bayesianApiPackageFlow
-            - bayesianPriorityPackageFlow
-            - bayesianPackageAnalysisFlow
-            - componentApiFlow
-            - dependencyIngestFlow
-            - osioUserNotificationFlow
-            - gitOperationsFlow
-            - golangCVEPredictionsFlow
-            - newPackageFlow
-            - newPackageAnalysisFlow
+          $ref: '#/components/schemas/Flows'
         source:
-          type: string
-          enum:
-            - api
-            - git-refresh
-            - report
-            - monitor
-          example: api
+          $ref: '#/components/schemas/Source'
 
     RequestPackageDetailsSelctiveEPV:
       title: Selective API Request Body
@@ -294,13 +297,7 @@ components:
         - task_names
       properties:
         ecosystem:
-          type: string
-          enum:
-            - maven
-            - pypi
-            - npm
-            - golang
-          example: maven
+          $ref: '#/components/schemas/Ecosystem'
         packages:
           type: array
           items:
@@ -315,26 +312,7 @@ components:
                   type: string
                   example: 20201115
         flow_name:
-          type: string
-          example: bayesianPackageFlow
-          enum:
-            - osioAnalysisFlow
-            - bayesianFlow
-            - bayesianApiFlow
-            - bayesianPriorityFlow
-            - bayesianAnalysisFlow
-            - livenessFlow
-            - bayesianPackageFlow
-            - bayesianApiPackageFlow
-            - bayesianPriorityPackageFlow
-            - bayesianPackageAnalysisFlow
-            - componentApiFlow
-            - dependencyIngestFlow
-            - osioUserNotificationFlow
-            - gitOperationsFlow
-            - golangCVEPredictionsFlow
-            - newPackageFlow
-            - newPackageAnalysisFlow
+          $ref: '#/components/schemas/Flows'
         task_names:
           type: array
           items:
@@ -354,10 +332,4 @@ components:
           type: boolean
           example: true
         source:
-          type: string
-          enum:
-            - api
-            - git-refresh
-            - report
-            - monitor
-          example: git-refresh
+          $ref: '#/components/schemas/Source'

--- a/f8a_jobs/api_spec.yaml
+++ b/f8a_jobs/api_spec.yaml
@@ -166,8 +166,12 @@ components:
       properties:
         ecosystem:
           type: string
-          enum: [maven, pypi, npm, golang]
-          example: <eco_system_name>
+          enum:
+            - maven
+            - pypi
+            - npm
+            - golang
+          example: maven
         packages:
           type: array
           items:
@@ -175,13 +179,13 @@ components:
             properties:
                 package:
                   type: string
-                  example: <package_name>
+                  example: org.json
                 version:
                   type: string
-                  example: <package_version>
+                  example: 20201115
                 dispacher_id:
                   type: string
-                  example: <selinon_dispacher_id>
+                  example: a4e397bf-c55a-4fdf-86f8-cd8f71b9256d
 
     ResponsePackageErrorDetails:
       title: API Error Response Body
@@ -190,8 +194,12 @@ components:
       properties:
         ecosystem:
           type: string
-          enum: [maven, pypi, npm, golang]
-          example: <eco_system_name>
+          enum:
+            - maven
+            - pypi
+            - npm
+            - golang
+          example: maven
         packages:
           type: array
           items:
@@ -199,10 +207,10 @@ components:
             properties:
                 pkg:
                   type: string
-                  example: <package_name>
+                  example: org.json
                 ver:
                   type: string
-                  example: <package_version>
+                  example: 20201115
                 error_message:
                   type: string
                   example: Incorrect data sent.
@@ -217,8 +225,12 @@ components:
       properties:
         ecosystem:
           type: string
-          enum: [maven, pypi, npm, golang]
-          example: <ecosystem_name>
+          enum:
+            - maven
+            - pypi
+            - npm
+            - golang
+          example: maven
         packages:
           type: array
           items:
@@ -229,10 +241,10 @@ components:
             properties:
                 package:
                   type: string
-                  example: <package_name>
+                  example: org.json
                 version:
                   type: string
-                  example: <package_version>
+                  example: 20201115
         force:
           type: boolean
           example: false
@@ -244,10 +256,33 @@ components:
           example: 0
         flow_name:
           type: string
-          example: <flow_name>
+          example: bayesianFlow
+          enum:
+            - osioAnalysisFlow
+            - bayesianFlow
+            - bayesianApiFlow
+            - bayesianPriorityFlow
+            - bayesianAnalysisFlow
+            - livenessFlow
+            - bayesianPackageFlow
+            - bayesianApiPackageFlow
+            - bayesianPriorityPackageFlow
+            - bayesianPackageAnalysisFlow
+            - componentApiFlow
+            - dependencyIngestFlow
+            - osioUserNotificationFlow
+            - gitOperationsFlow
+            - golangCVEPredictionsFlow
+            - newPackageFlow
+            - newPackageAnalysisFlow
         source:
           type: string
-          example: <name_of_consumer>
+          enum:
+            - api
+            - git-refresh
+            - report
+            - monitor
+          example: api
 
     RequestPackageDetailsSelctiveEPV:
       title: Selective API Request Body
@@ -260,8 +295,12 @@ components:
       properties:
         ecosystem:
           type: string
-          enum: [maven, pypi, npm, golang]
-          example: <ecosystem_name>
+          enum:
+            - maven
+            - pypi
+            - npm
+            - golang
+          example: maven
         packages:
           type: array
           items:
@@ -271,18 +310,40 @@ components:
             properties:
                 package:
                   type: string
-                  example: <package_name>
+                  example: org.json
                 version:
                   type: string
-                  example: <package_version>
+                  example: 20201115
         flow_name:
           type: string
-          example: <flow_name>
+          example: bayesianPackageFlow
+          enum:
+            - osioAnalysisFlow
+            - bayesianFlow
+            - bayesianApiFlow
+            - bayesianPriorityFlow
+            - bayesianAnalysisFlow
+            - livenessFlow
+            - bayesianPackageFlow
+            - bayesianApiPackageFlow
+            - bayesianPriorityPackageFlow
+            - bayesianPackageAnalysisFlow
+            - componentApiFlow
+            - dependencyIngestFlow
+            - osioUserNotificationFlow
+            - gitOperationsFlow
+            - golangCVEPredictionsFlow
+            - newPackageFlow
+            - newPackageAnalysisFlow
         task_names:
           type: array
           items:
             type: string
-          example: [TASK_1, TASK_2, TASK_3, TASK_4]
+          example: [
+            'github_details',
+            'PackageFinalizeTask',
+            'PackageResultCollector',
+            'PackageGraphImporterTask']
         follow_subflows:
           type: boolean
           example: True
@@ -292,3 +353,11 @@ components:
         force:
           type: boolean
           example: true
+        source:
+          type: string
+          enum:
+            - api
+            - git-refresh
+            - report
+            - monitor
+          example: git-refresh

--- a/f8a_jobs/graph_ingestion.py
+++ b/f8a_jobs/graph_ingestion.py
@@ -9,14 +9,8 @@ from f8a_utils.tree_generator import GolangDependencyTreeGenerator
 
 logger = logging.getLogger(__name__)
 
-_INVOKE_API_WORKERS = True \
-    if os.environ.get('INVOKE_API_WORKERS', 'True') == 'True' \
-    else False
-
-_DISABLE_UNKNOWN_PACKAGE_FLOW = True \
-    if os.environ.get('DISABLE_UNKNOWN_PACKAGE_FLOW', 'False') == 'True' \
-    else False
-
+_INVOKE_API_WORKERS = os.environ.get('INVOKE_API_WORKERS', 'True') == 'True'
+_DISABLE_UNKNOWN_PACKAGE_FLOW = os.environ.get('DISABLE_UNKNOWN_PACKAGE_FLOW', 'False') == 'True'
 _SUPPORTED_ECOSYSTEMS = {'npm', 'maven', 'pypi', 'golang'}
 
 
@@ -44,71 +38,59 @@ def ingest_epv_into_graph(epv_details):
     """
     logger.info('graph_ingestion_:_ingest_epv_into_graph() is called.')
     input_data = epv_details.get('body', {})
-    source = input_data.get('source', '')
 
-    if source == 'api' and _DISABLE_UNKNOWN_PACKAGE_FLOW:
+    # Check if worker flow activation is disabled.
+    if not _INVOKE_API_WORKERS:
+        logger.debug('Worker flows are disabled.')
+        input_data['message'] = 'Worker flows are disabled.'
+        return input_data, 201
+
+    # Check if API consumer is CA or SA and unknown package ingestion flag is disabled.
+    if _DISABLE_UNKNOWN_PACKAGE_FLOW and input_data.get('source', '') == 'api':
         logger.debug('Unknown package ingestion is disabled.')
         input_data['message'] = 'Unknown package ingestion is disabled.'
         return input_data, 201
 
-    # Check if EPV ingestion is enabled.
-    if _INVOKE_API_WORKERS:
-        ecosystem = input_data.get('ecosystem')
-        force = input_data.get('force', True)
-        force_graph_sync = input_data.get('force_graph_sync', False)
-        recursive_limit = input_data.get('recursive_limit', 0)
+    gh = GithubUtils()
+    ecosystem = input_data.get('ecosystem')
+    package_list = input_data.get('packages')
 
-        # Check if requested ecosystem for ingestion is supported,
-        # if not then set an error message.
-        if ecosystem in _SUPPORTED_ECOSYSTEMS:
-            package_list = input_data.get('packages')
-            gh = GithubUtils()
+    node_arguments = {
+        "ecosystem": ecosystem,
+        "force": input_data.get('force', True),
+        "recursive_limit": input_data.get('recursive_limit', 0),
+        "force_graph_sync": input_data.get('force_graph_sync', False)
+    }
 
-            try:
-                # Iterate through packages given for current ecosystem.
-                for item in package_list:
-                    # Check if required keys are present in input data,
-                    # if not then add item in filed list.
-                    if {'package', 'version'}.issubset(item.keys()):
-                        if ecosystem == 'golang':
-                            _, clean_version = GolangDependencyTreeGenerator.\
-                                clean_version(item.get('version'))
-                            if gh.is_pseudo_version(clean_version):
-                                item['error_message'] = 'Golang pseudo version is not supported.'
-                                continue
+    # Iterate through packages given for current ecosystem.
+    for item in package_list:
+        if ecosystem == 'golang':
+            _, clean_version = GolangDependencyTreeGenerator.\
+                clean_version(item.get('version'))
+            if gh.is_pseudo_version(clean_version):
+                item['error_message'] = 'Golang pseudo version is not supported.'
+                continue
 
-                        node_arguments = {
-                            "ecosystem": ecosystem,
-                            "force": force,
-                            "force_graph_sync": force_graph_sync,
-                            "name": item.get('package'),
-                            "recursive_limit": recursive_limit,
-                            "version": item.get('version')
-                        }
+        flow_name = 'newPackageFlow' if ecosystem == 'golang' else 'bayesianApiFlow'
 
-                        flow_name = 'newPackageFlow' \
-                            if ecosystem == 'golang' \
-                            else 'bayesianApiFlow'
+        if 'flow_name' in input_data:
+            flow_name = input_data['flow_name']
 
-                        if 'flow_name' in input_data:
-                            flow_name = input_data['flow_name']
+        node_arguments['name'] = item.get('package')
+        node_arguments['version'] = item.get('version')
 
-                        # Initiate Selinon flow for current EPV ingestion.
-                        dispacher_id = run_server_flow(flow_name, node_arguments)
-                        item['dispacher_id'] = dispacher_id.id
+        try:
+            # Initiate Selinon flow for current EPV ingestion.
+            dispacher_id = run_flow(flow_name, node_arguments)
+            item['dispacher_id'] = dispacher_id.id
+        except Exception as e:
+            logger.error('Exception while initiating the worker flow %s', e)
+            return {'message': 'Failed to initiate worker flow.'}, 500
 
-                        logger.info('A %s in initiated for eco: %s, pkg: %s, ver: %s',
-                                    flow_name, ecosystem, item['package'], item['version'])
-                    else:
-                        logger.error('Incorrect data sent for %s: %s:', ecosystem, item)
-                        item['error_message'] = 'Incorrect data.'
-            except Exception as e:
-                logger.error('Exception while initiating the worker flow %s', e)
-                return {'message': 'Failed to initiate worker flow.'}, 500
-        else:
-            input_data['error_message'] = 'Unsupported ecosystem.'
+        logger.info('A %s in initiated for eco: %s, pkg: %s, ver: %s',
+                    flow_name, ecosystem, item['package'], item['version'])
 
-        return input_data, 201
+    return input_data, 201
 
 
 def ingest_selective_epv_into_graph(epv_details):
@@ -141,71 +123,57 @@ def ingest_selective_epv_into_graph(epv_details):
         }
     """
     logger.info('graph_ingestion_:_ingest_selective_epv_into_graph is called.')
+    input_data = epv_details.get('body', {})
 
-    # Check if EPV ingestion is enabled.
-    if _INVOKE_API_WORKERS:
-        input_data = epv_details.get('body', {})
-        source = input_data.get('source', '')
-        ecosystem = input_data.get('ecosystem')
-        package_list = input_data.get('packages')
-        task_names = input_data.get('task_names')
-        force = input_data.get('force', True)
-        follow_subflows = input_data.get('follow_subflows', False)
-        run_subsequent = input_data.get('run_subsequent', False)
-
-        input_data.pop('follow_subflows', None)
-        input_data.pop('run_subsequent', None)
-        input_data.pop('task_names', None)
-        input_data.pop('force', None)
-
-        if source == 'git-refresh':
-            flow_name = 'newPackageAnalysisFlow' \
-                if ecosystem == 'golang' \
-                else 'bayesianPackageFlow'
-
-        if 'flow_name' in input_data:
-            flow_name = input_data['flow_name']
-
-        # Iterate through packages given for current ecosystem.
-        for item in package_list:
-            node_arguments = {
-                "ecosystem": ecosystem,
-                "force": force,
-                "name": item.get('package'),
-            }
-
-            if 'url' in item:
-                node_arguments['url'] = item['url']
-            if 'version' in item:
-                node_arguments['version'] = item['version']
-
-            try:
-                # Initiate Selinon flow for current EPV ingestion.
-                dispacher_id = run_flow_selective(flow_name,
-                                                  task_names,
-                                                  node_arguments,
-                                                  follow_subflows,
-                                                  run_subsequent)
-            except Exception as e:
-                logger.error('Exception while initiating the worker flow %s', e)
-                return {'message': 'Failed to initiate worker flow.'}, 500
-
-            item['dispacher_id'] = dispacher_id.id
-
-            logger.info('A selective flow "%s" in initiated for '
-                        'eco: %s, pkg: %s, for task list: %s',
-                        flow_name, ecosystem, item['package'], task_names)
+    # Check if worker flow activation is disabled.
+    if not _INVOKE_API_WORKERS:
+        logger.debug('Worker flows are disabled.')
+        input_data['message'] = 'Worker flows are disabled.'
         return input_data, 201
 
+    ecosystem = input_data.get('ecosystem')
+    package_list = input_data.get('packages')
+    task_names = input_data.get('task_names')
+    follow_subflows = input_data.get('follow_subflows', False)
+    run_subsequent = input_data.get('run_subsequent', False)
 
-def run_server_flow(flow_name, node_args):
-    """To run the worker flow via selinon.
+    if input_data.get('source', '') == 'git-refresh':
+        flow_name = 'newPackageAnalysisFlow' \
+            if ecosystem == 'golang' else 'bayesianPackageFlow'
 
-    :param flow_name: Name of the ingestion flow
-    :param node_args: Details required by Selinon task manager for triggering a flow.
-    :return: Selinon Dispatcher ID associated to flow started.
-    """
-    return run_flow(flow_name, node_args)
+    if 'flow_name' in input_data:
+        flow_name = input_data['flow_name']
+
+    node_arguments = {
+        "ecosystem": ecosystem,
+        "force": input_data.get('force', True)
+    }
+
+    # Iterate through packages given for current ecosystem.
+    for item in package_list:
+        node_arguments["name"] = item.get('package')
+
+        if 'url' in item:
+            node_arguments['url'] = item['url']
+        if 'version' in item:
+            node_arguments['version'] = item['version']
+
+        try:
+            # Initiate Selinon flow for current EPV ingestion.
+            dispacher_id = run_flow_selective(flow_name,
+                                              task_names,
+                                              node_arguments,
+                                              follow_subflows,
+                                              run_subsequent)
+            item['dispacher_id'] = dispacher_id.id
+        except Exception as e:
+            logger.error('Exception while initiating the worker flow %s', e)
+            return {'message': 'Failed to initiate worker flow.'}, 500
+
+        logger.info('A selective flow "%s" in initiated for '
+                    'eco: %s, pkg: %s, for task list: %s',
+                    flow_name, ecosystem, item['package'], task_names)
+    return input_data, 201
 
 
 @validate_user

--- a/f8a_jobs/graph_ingestion.py
+++ b/f8a_jobs/graph_ingestion.py
@@ -10,7 +10,7 @@ from f8a_utils.tree_generator import GolangDependencyTreeGenerator
 logger = logging.getLogger(__name__)
 
 _INVOKE_API_WORKERS = True \
-    if os.environ.get('INVOKE_API_WORKERS', '1') == '1' \
+    if os.environ.get('INVOKE_API_WORKERS', 'True') == 'True' \
     else False
 
 _DISABLE_UNKNOWN_PACKAGE_FLOW = True \

--- a/f8a_jobs/graph_ingestion.py
+++ b/f8a_jobs/graph_ingestion.py
@@ -14,7 +14,7 @@ _INVOKE_API_WORKERS = True \
     else False
 
 _DISABLE_UNKNOWN_PACKAGE_FLOW = True \
-    if os.environ.get('DISABLE_UNKNOWN_PACKAGE_FLOW', '0') == '1' \
+    if os.environ.get('DISABLE_UNKNOWN_PACKAGE_FLOW', 'False') == 'True' \
     else False
 
 _SUPPORTED_ECOSYSTEMS = {'npm', 'maven', 'pypi', 'golang'}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -105,7 +105,7 @@ objects:
                 name: coreapi-postgres
                 key: password
           - name: INVOKE_API_WORKERS
-            value: "1"
+            value: "True"
           - name: DISABLE_UNKNOWN_PACKAGE_FLOW
             value: "False"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -106,6 +106,8 @@ objects:
                 key: password
           - name: INVOKE_API_WORKERS
             value: "1"
+          - name: DISABLE_UNKNOWN_PACKAGE_FLOW
+            value: "0"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: bayesian-jobs
           ports:
@@ -165,6 +167,7 @@ objects:
     name: bayesian-jobs
   spec:
     host: ${BAYESIAN_JOBS_HOSTNAME}
+    path: /ingestions
     to:
       kind: Service
       name: bayesian-jobs

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -107,7 +107,7 @@ objects:
           - name: INVOKE_API_WORKERS
             value: "1"
           - name: DISABLE_UNKNOWN_PACKAGE_FLOW
-            value: "0"
+            value: "False"
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: bayesian-jobs
           ports:

--- a/tests/test_graph_ingestion.py
+++ b/tests/test_graph_ingestion.py
@@ -103,20 +103,18 @@ data_v6 = {
         }
 
 data_v7 = {
-            'body': {
-                "ecosystem": "nuget",
-                "packages": [{
-                    "package": "pkg1"
-                }
-                ],
-                "flow_name": "flow_name",
-                "task_names": [
-                    "TASK_1",
-                    "TASK_2",
-                    "TASK_3",
-                    "TASK_4"
-                ]
+            "ecosystem": "nuget",
+            "packages": [{
+                "package": "pkg1"
             }
+            ],
+            "source": "git-refresh",
+            "task_names": [
+                "TASK_1",
+                "TASK_2",
+                "TASK_3",
+                "TASK_4"
+            ]
         }
 
 data_v8 = {
@@ -139,6 +137,18 @@ data_v9 = {
                 }
                 ],
                 "source": "api"
+            }
+        }
+
+data_v10 = {
+            'body': {
+                "ecosystem": "npm",
+                "packages": [{
+                    "package": "pkg1",
+                    "version": "ver1"
+                }
+                ],
+                "flow_name": None
             }
         }
 
@@ -184,7 +194,7 @@ def test_ingest_epv_into_graph1(_mock):
 
 def test_ingest_epv_into_graph4():
     """Tests for 'ingest_epv_into_graph'."""
-    result = ingest_epv_into_graph(None)
+    result = ingest_epv_into_graph(data_v10)
     expected = ({"message": "Failed to initiate worker flow."}, 500)
     assert result == expected
 
@@ -261,13 +271,6 @@ def test_ingest_selective_epv_into_graph2(_mock):
                         "version": "ver1"
                     }]
                 }, 201)
-    assert result == expected
-
-
-def test_ingest_selective_epv_into_graph3():
-    """Tests for 'ingest_epv_into_graph'."""
-    result = ingest_selective_epv_into_graph(None)
-    expected = ({"message": "Failed to initiate worker flow."}, 500)
     assert result == expected
 
 


### PR DESCRIPTION
# Description
Introduced new auth free ingestion end points which will be used internally and can not be exposed through public route.

## API Spec
https://app.swaggerhub.com/apis/jparsai/Jobs_API/0.1?loggedInWithGitHub=true

## Type of change
- [x] Modified route to expose API having endpoint prefix 'ingestion'. 
- [x] Updated API spec to add new endpoints.
- [x] Introduced a new optional parameter 'source' in request body to identify caller of API, which is required for different validations and to set the flow name. 
- [x] Validation to enable/disable unknown flow ingestion if caller is SA/CA component.
- [x] 100% test coverage for ingestion APIs.
- [x] Removed some test cases for ecosystem validation as conexion will not allow any request to go through if supplied ecosystem is not present in enum.