### PR TITLE
fix: Expose v1 end points via public route.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -172,6 +172,16 @@ objects:
       kind: Service
       name: bayesian-jobs
 - apiVersion: v1
+  kind: Route
+  metadata:
+    name: bayesian-jobs-v1
+  spec:
+    host: ${BAYESIAN_JOBS_HOSTNAME}
+    path: /api/v1
+    to:
+      kind: Service
+      name: bayesian-jobs
+- apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: bayesian-jobs-pvc


### PR DESCRIPTION
# Description

Exposing "api/v1" end point via external route to get access to existing authentication API's 

# Type of changes
 - [x] Added new route for '/api/v1' endpoint, as existing route exposes 'ingestion' endpoint
 - [x] Modified logs messages to print caller of API, as its used my many components and it gets difficult to find the source of ingestion request. 
 